### PR TITLE
feat: maxVersions and ubuntu code names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,6 +191,13 @@ jobs:
           config: e2e/renovate.json
           dry-run: true
 
+      - name: docker-builder (ubuntu)
+        uses: ./
+        with:
+          command: docker-builder
+          config: e2e/ubuntu.json
+          dry-run: true
+
       - name: dummy-command
         uses: ./
         with:

--- a/e2e/ubuntu.json
+++ b/e2e/ubuntu.json
@@ -1,0 +1,7 @@
+{
+  "datasource": "docker",
+  "versioning": "ubuntu",
+  "image": "ubuntu",
+  "startVersion": "bionic",
+  "versions": ["bionic", "focal"]
+}

--- a/src/commands/docker/builder.ts
+++ b/src/commands/docker/builder.ts
@@ -70,17 +70,17 @@ async function getBuildList({
     latestVersion ||
     pkgResult.latestVersion ||
     allVersions.filter((v) => ver.isStable(v)).pop();
-  log('Latest stable version is ', latestStable);
+  log('Latest stable version is', latestStable);
 
   if (latestStable && !allVersions.includes(latestStable)) {
     log.warn(
-      `LatestStable '${latestStable}' not buildable, candidates: `,
+      `LatestStable '${latestStable}' not buildable, candidates:`,
       allVersions.join(', ')
     );
   }
 
   const lastVersion = allVersions[allVersions.length - 1];
-  log('Most recent version is ', lastVersion);
+  log('Most recent version is', lastVersion);
 
   if (lastOnly) {
     log('Building last version only');
@@ -88,7 +88,7 @@ async function getBuildList({
   }
 
   if (allVersions.length) {
-    log('Build list: ', allVersions.join(', '));
+    log('Build list:', allVersions.join(', '));
   } else {
     log('Nothing to build');
   }
@@ -215,11 +215,11 @@ async function buildAndPush(
   }
 
   if (builds.length) {
-    log('Build list: ' + builds.join(' '));
+    log('Build list:' + builds.join(' '));
   }
 
   if (failed.length) {
-    log.warn('Failed list: ' + failed.join(' '));
+    log.warn('Failed list:' + failed.join(' '));
     throw new Error('failed');
   }
 }

--- a/src/commands/docker/builder.ts
+++ b/src/commands/docker/builder.ts
@@ -34,6 +34,7 @@ async function getBuildList({
   forceUnstable,
   versions,
   latestVersion,
+  maxVersions,
 }: Config): Promise<string[]> {
   log('Looking up versions');
   const ver = getVersioning(versioning as never);
@@ -81,6 +82,11 @@ async function getBuildList({
 
   const lastVersion = allVersions[allVersions.length - 1];
   log('Most recent version is', lastVersion);
+
+  if (is.number(maxVersions) && maxVersions > 0) {
+    log(`Building last ${maxVersions} version only`);
+    allVersions = allVersions.slice(-maxVersions);
+  }
 
   if (lastOnly) {
     log('Building last version only');
@@ -236,6 +242,7 @@ type ConfigFile = {
   forceUnstable?: boolean;
   versions?: string[];
   latestVersion?: string;
+  maxVersions?: number;
 };
 
 type Config = {

--- a/src/utils/versioning/index.ts
+++ b/src/utils/versioning/index.ts
@@ -1,9 +1,11 @@
 import { getVersionings } from 'renovate/dist/versioning';
 import log from '../logger';
 import * as node from './node';
+import * as ubuntu from './ubuntu';
 
 export function register(): void {
   log('register versionings');
   const ds = getVersionings();
   ds.set(node.id, node.api);
+  ds.set(ubuntu.id, ubuntu.api);
 }

--- a/src/utils/versioning/ubuntu.ts
+++ b/src/utils/versioning/ubuntu.ts
@@ -1,0 +1,59 @@
+import { VersioningApi } from 'renovate/dist/versioning';
+import * as generic from 'renovate/dist/versioning/loose/generic';
+
+const versions = new Map<string, generic.GenericVersion>([
+  ['bionic', { release: [18, 4] }],
+  ['18.04', { release: [18, 4] }],
+  ['focal', { release: [20, 4] }],
+  ['20.04', { release: [20, 4] }],
+]);
+
+export const id = 'ubuntu';
+
+function parse(version: string): generic.GenericVersion {
+  return versions.get(version) as generic.GenericVersion;
+}
+
+function compare(version1: string, version2: string): number {
+  const parsed1 = parse(version1);
+  const parsed2 = parse(version2);
+  // istanbul ignore if
+  if (!parsed1 || !parsed2) {
+    return 1;
+  }
+  const length = Math.max(parsed1.release.length, parsed2.release.length);
+  for (let i = 0; i < length; i += 1) {
+    const part1 = parsed1.release[i];
+    const part2 = parsed2.release[i];
+    // shorter is bigger 2.1 > 2.1.1
+    // istanbul ignore if
+    if (part1 === undefined) {
+      return 1;
+    }
+    // istanbul ignore if
+    if (part2 === undefined) {
+      return -1;
+    }
+    if (part1 !== part2) {
+      return part1 - part2;
+    }
+  }
+  return 0;
+}
+
+function isCompatible(version: string, range: string): boolean {
+  const parsed1 = parse(version);
+  const parsed2 = parse(range);
+  return parsed1 != null && parsed2 != null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+export const api: VersioningApi = {
+  ...generic.create({
+    parse,
+    compare,
+  }),
+  isCompatible,
+};
+
+export default api;

--- a/test/commands/docker/__fixtures__/gradle.json
+++ b/test/commands/docker/__fixtures__/gradle.json
@@ -2,5 +2,6 @@
   "datasource": "gradle-version",
   "versioning": "gradle",
   "image": "gradle",
-  "startVersion": "3.5.4"
+  "startVersion": "3.5.4",
+  "maxVersions": 3
 }

--- a/test/commands/docker/__fixtures__/ubuntu.json
+++ b/test/commands/docker/__fixtures__/ubuntu.json
@@ -1,0 +1,7 @@
+{
+  "datasource": "docker",
+  "versioning": "ubuntu",
+  "image": "ubuntu",
+  "startVersion": "bionic",
+  "versions": ["bionic", "focal"]
+}

--- a/test/commands/docker/__snapshots__/builder.spec.ts.snap
+++ b/test/commands/docker/__snapshots__/builder.spec.ts.snap
@@ -306,6 +306,97 @@ Array [
 ]
 `;
 
+exports[`works ubuntu: build 1`] = `
+Array [
+  Array [
+    Object {
+      "buildArgs": Array [
+        "UBUNTU_VERSION=bionic",
+      ],
+      "cache": undefined,
+      "cacheTags": Array [
+        "latest",
+        "18",
+        "18.4",
+      ],
+      "dryRun": undefined,
+      "image": "ubuntu",
+      "tag": "bionic",
+    },
+  ],
+  Array [
+    Object {
+      "buildArgs": Array [
+        "UBUNTU_VERSION=focal",
+      ],
+      "cache": undefined,
+      "cacheTags": Array [
+        "latest",
+        "20",
+        "20.4",
+      ],
+      "dryRun": undefined,
+      "image": "ubuntu",
+      "tag": "focal",
+    },
+  ],
+]
+`;
+
+exports[`works ubuntu: publish 1`] = `
+Array [
+  Array [
+    Object {
+      "dryRun": undefined,
+      "image": "ubuntu",
+      "tag": "bionic",
+    },
+  ],
+  Array [
+    Object {
+      "dryRun": undefined,
+      "image": "ubuntu",
+      "tag": "18",
+    },
+  ],
+  Array [
+    Object {
+      "dryRun": undefined,
+      "image": "ubuntu",
+      "tag": "18.4",
+    },
+  ],
+  Array [
+    Object {
+      "dryRun": undefined,
+      "image": "ubuntu",
+      "tag": "focal",
+    },
+  ],
+  Array [
+    Object {
+      "dryRun": undefined,
+      "image": "ubuntu",
+      "tag": "20",
+    },
+  ],
+  Array [
+    Object {
+      "dryRun": undefined,
+      "image": "ubuntu",
+      "tag": "20.4",
+    },
+  ],
+  Array [
+    Object {
+      "dryRun": undefined,
+      "image": "ubuntu",
+      "tag": "latest",
+    },
+  ],
+]
+`;
+
 exports[`works yarn: build 1`] = `
 Array [
   Array [

--- a/test/commands/docker/__snapshots__/builder.spec.ts.snap
+++ b/test/commands/docker/__snapshots__/builder.spec.ts.snap
@@ -173,7 +173,7 @@ Array [
   Array [
     Object {
       "buildArgs": Array [
-        "GRADLE_VERSION=3.5.4",
+        "GRADLE_VERSION=3.5.5",
       ],
       "cache": undefined,
       "cacheTags": Array [
@@ -183,7 +183,22 @@ Array [
       ],
       "dryRun": undefined,
       "image": "gradle",
-      "tag": "3.5.4",
+      "tag": "3.5.5",
+    },
+  ],
+  Array [
+    Object {
+      "buildArgs": Array [
+        "GRADLE_VERSION=4.5",
+      ],
+      "cache": undefined,
+      "cacheTags": Array [
+        "latest",
+        "4",
+      ],
+      "dryRun": undefined,
+      "image": "gradle",
+      "tag": "4.5",
     },
   ],
   Array [
@@ -210,7 +225,7 @@ Array [
     Object {
       "dryRun": undefined,
       "image": "gradle",
-      "tag": "3.5.4",
+      "tag": "3.5.5",
     },
   ],
   Array [
@@ -225,6 +240,20 @@ Array [
       "dryRun": undefined,
       "image": "gradle",
       "tag": "3.5",
+    },
+  ],
+  Array [
+    Object {
+      "dryRun": undefined,
+      "image": "gradle",
+      "tag": "4.5",
+    },
+  ],
+  Array [
+    Object {
+      "dryRun": undefined,
+      "image": "gradle",
+      "tag": "4",
     },
   ],
   Array [

--- a/test/commands/docker/builder.spec.ts
+++ b/test/commands/docker/builder.spec.ts
@@ -67,12 +67,20 @@ describe(getName(__filename), () => {
         { version: '2.3' },
         { version: '3.0' },
         { version: '3.5.4' },
+        { version: '3.5.5' },
+        { version: '4.5' },
         { version: '6.0' },
       ],
     });
 
     await run();
 
+    expect(docker.build.mock.calls).toHaveLength(3);
+    expect(docker.build.mock.calls.map(([args]) => args.tag)).toEqual([
+      '3.5.5',
+      '4.5',
+      '6.0',
+    ]);
     expect(docker.build.mock.calls).toMatchSnapshot('build');
     expect(docker.publish.mock.calls).toMatchSnapshot('publish');
   });

--- a/test/commands/docker/builder.spec.ts
+++ b/test/commands/docker/builder.spec.ts
@@ -12,7 +12,7 @@ jest.mock('../../../src/utils/docker');
 jest.mock('../../../src/utils/docker/buildx', () => ({
   init: () => Promise.resolve(),
 }));
-jest.mock('../../../src/utils/renovate');
+jest.mock('../../../src/utils/datasource');
 
 const core = mocked(_core);
 const utils = mocked(_utils);
@@ -80,6 +80,16 @@ describe(getName(__filename), () => {
   it('works dummy', async () => {
     jest.resetAllMocks();
     utils.readJson.mockResolvedValueOnce(require('./__fixtures__/dummy.json'));
+
+    await run();
+
+    expect(docker.build.mock.calls).toMatchSnapshot('build');
+    expect(docker.publish.mock.calls).toMatchSnapshot('publish');
+  });
+
+  it('works ubuntu', async () => {
+    jest.resetAllMocks();
+    utils.readJson.mockResolvedValueOnce(require('./__fixtures__/ubuntu.json'));
 
     await run();
 

--- a/test/utils/versioning/ubuntu.spec.ts
+++ b/test/utils/versioning/ubuntu.spec.ts
@@ -1,0 +1,28 @@
+import { api } from '../../../src/utils/versioning/ubuntu';
+import { getName } from '../../utils';
+
+describe(getName(__filename), () => {
+  it('isVersion', () => {
+    expect(api.isVersion('bionic')).toEqual('bionic');
+    expect(api.isVersion('focal')).toEqual('focal');
+    expect(api.isVersion('groovy')).toBeNull();
+  });
+  it('isStable', () => {
+    expect(api.isStable('bionic')).toEqual(true);
+    expect(api.isStable('13.16.3')).toBeUndefined();
+    expect(api.isStable('groovy')).toBeUndefined();
+  });
+
+  it('isCompatible', () => {
+    expect(api.isCompatible('bionic', '18.04')).toEqual(true);
+    expect(api.isCompatible('bionic', '20.04')).toEqual(true);
+    expect(api.isCompatible('20.10', '20.04')).toEqual(false);
+  });
+
+  it('sortVersions', () => {
+    expect(api.sortVersions('bionic', '18.04')).toEqual(0);
+    expect(
+      ['18.04', 'bionic', '20.04'].sort((a, b) => api.sortVersions(a, b))
+    ).toEqual(['18.04', 'bionic', '20.04']);
+  });
+});


### PR DESCRIPTION
* docker builder now supports building ubuntu base images with code names
* amount of version to build can be limited by `maxVersions` option in `builder.json`