### PR TITLE
chore: target es2021

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "compile": "cd src && ncc build ./index.ts -o ../dist -s --target es2020",
+    "compile": "cd src && ncc build ./index.ts -o ../dist -s --target es2021",
     "eslint": "eslint .",
     "eslint:fix": "yarn eslint --fix",
     "lint": "run-s eslint prettier",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,13 @@
 {
   "compilerOptions": {
     "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
     "outDir": "./dist",
-    "target": "es2019",
+    "target": "ES2021",
     "module": "commonjs",
     "moduleResolution": "node",
-    "resolveJsonModule": false,
     "importHelpers": true,
     "useUnknownInCatchVariables": false /* we aren't prepared for enabling this by default since ts 4.4*/,
-    "lib": ["es2019"],
+    "lib": ["ES2021"],
     "types": ["node", "jest"]
   },
   "exclude": ["node_modules", "**/__mocks__/*"]


### PR DESCRIPTION
Now that we're running on Node 16 we can make use of ES2021 features.

This PR also removes redundant `compilerOptions` from `tsconfig.json`.