### PR TITLE
feat(binary-builder): defer version asset upload

### DIFF
--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -11,7 +11,7 @@ import type { BinaryBuilderConfig } from './types';
 
 export { getOctokit };
 
-type GitHubOctokit = InstanceType<typeof GitHub>;
+export type GitHubOctokit = InstanceType<typeof GitHub>;
 
 interface GhAsset {
   name: string;

--- a/test/commands/binary/index.spec.ts
+++ b/test/commands/binary/index.spec.ts
@@ -48,7 +48,7 @@ describe('commands/binary/index', () => {
     await run();
 
     expect(docker.dockerRun).not.toHaveBeenCalled();
-    expect(github.uploadVersionAsset).toHaveBeenCalled();
+    expect(github.uploadVersionAsset).not.toHaveBeenCalled();
   });
 
   it('works ruby (dry-run)', async () => {


### PR DESCRIPTION
Should be deferred until at least one binary aset is uploaded. Otherwise we've an empty release like it happned on php 8.4.1