### PR TITLE
feat(pnpm): use standalone variant to support old node testing

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -79,6 +79,7 @@ runs:
       if: inputs.node == 'true' || inputs.pnpm == 'true'
       with:
         cache: ${{ (env.CACHE_HIT != 'true' || runner.os == 'Windows') && inputs.read-cache == 'true' }}
+        standalone: true
 
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       if: inputs.node == 'true'


### PR DESCRIPTION
standalone mode brings a precompiled pnpm with included nodejs, so newer pnpm works on older node

```sh
$ pnpm install --frozen-lockfile
warn: This version of pnpm requires at least Node.js v22.13
warn: The current version of Node.js is v20.20.2
warn: Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.
node:internal/modules/cjs/loader:1031
      throw new ERR_UNKNOWN_BUILTIN_MODULE(request);
```